### PR TITLE
Add .env.submit to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ web-ext.config.ts
 *.njsproj
 *.sln
 *.sw?
+
+.env.submit

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ web-ext.config.ts
 *.sln
 *.sw?
 
-.env.submit
+.env.submit*


### PR DESCRIPTION
I add `.env.submit` to `.gitignore`.
This file contains secrets for publishing those extensions.

FYI: https://wxt.dev/guide/essentials/publishing#automation