### PR TITLE
Revert "Use MatchPattern instead of RegExp"

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -3,7 +3,12 @@ import {
   getColorSettingsFromStorage,
   colorSettingZodType,
 } from "@/modules/color_settings.ts";
-import { signinMatchPattern, matches, MessageType } from "@/modules/lib.ts";
+import {
+  signinMatchPattern,
+  matches,
+  MessageType,
+  matchURL,
+} from "@/modules/lib.ts";
 
 type GetHTMLElementType = () => HTMLElement | null;
 
@@ -204,7 +209,7 @@ async function onConsoleMessage(
 }
 
 async function main() {
-  if (new MatchPattern(signinMatchPattern).includes(document.documentURI)) {
+  if (matchURL(signinMatchPattern, document.documentURI)) {
     if (
       !document.documentURI.includes(".signin.aws.amazon.com/sessions/selector")
     ) {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -7,7 +7,7 @@ import {
   colorSettingsZodType,
   getColorSettingsFromStorage,
 } from "@/modules/color_settings.ts";
-import { matches, MessageType } from "@/modules/lib.ts";
+import { matches, MessageType, matchURL } from "@/modules/lib.ts";
 import "react-color-palette/css";
 import "./App.css";
 
@@ -106,7 +106,7 @@ async function sendMessageToContentScript(
   }
 
   const filteredMatches = matches.filter((m) => {
-    return new MatchPattern(m).includes(z.string().parse(tabs[0].url));
+    return matchURL(m, z.string().parse(tabs[0].url));
   });
   return 0 < filteredMatches.length
     ? await browser.tabs.sendMessage(z.number().parse(tabs[0].id), message)

--- a/modules/lib.ts
+++ b/modules/lib.ts
@@ -10,3 +10,7 @@ export const matches: Manifest.ContentScript["matches"] = [
   "*://*.console.aws.amazon.com/*",
   signinMatchPattern,
 ];
+
+export function matchURL(matchPattern: string, url: string): boolean {
+  return new RegExp(matchPattern.replaceAll("*", ".*")).exec(url) !== null;
+}


### PR DESCRIPTION
I revert massongit/aws-management-console-colorize#50 because it does not work well.