### PR TITLE
Fix warnings of super-linter

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -65,6 +65,9 @@ overrides:
       - prettier
     rules:
       n/no-missing-import: off
+    settings:
+      react:
+        version: detect
     parser: "@typescript-eslint/parser"
     plugins:
       - "@typescript-eslint"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -57,7 +57,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           LINTER_RULES_PATH: .
-          TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,8 @@
+// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  helpUrl: "https://www.conventionalcommits.org/",
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};


### PR DESCRIPTION
I fix the following warnings:

https://github.com/massongit/aws-management-console-colorize/actions/runs/13736140713/job/38420050790#step:6:149

```
  2025-03-08 09:16:50 [WARN]   Git commit message validation with commitlint is enabled, but no commitlint configuration file is available. Disabling commitlint. To suppress this message, either disable Git commit validation by setting VALIDATE_GIT_COMMITLINT to false in your Super-linter configuration, or provide a commitlint configuration file.
  2025-03-08 09:16:50 [WARN]   TYPESCRIPT_DEFAULT_STYLE environment variable is set, it's deprecated, and super-linter will ignore it. Remove it from your configuration. This warning may turn in a fatal error in the future. For more information, see the upgrade guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md
```

https://github.com/massongit/aws-management-console-colorize/actions/runs/13736140713/job/38420050790#step:6:417

```
  Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```