### PR TITLE
Update the session ARN options on deletion

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -205,6 +205,7 @@ async function setColorSetting({
   await storage.setItem(colorSettingsStorageItemKey, colorSettings);
   await sendMessageToContentScript(MessageType.changeColor);
   const newColorSettings = await getColorSettings(getColorSettingsParams);
+  getColorSettingsParams.setColorSettings(newColorSettings);
 
   if (newColorSettings.length === 0) {
     return;

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -79,6 +79,7 @@ export async function checkInitializeState(
   testData: checkInitializeStateParams,
 ): Promise<void> {
   await expectSessionARN({ ...testData, sessionARN: testData.newSessionARN });
+  await expect(testData.sessionARNsSelect.locator("option")).toHaveCount(1);
   await expect(testData.hexColorInput).toHaveValue("#161d26");
   await expect(testData.addButton).toBeDisabled();
   await expect(testData.updateButton).toBeHidden();


### PR DESCRIPTION
Even if we deleted the session ARN setting, it will remain in the session ARN options.
Therefore, I fix to update the session ARN options on deletion.