### PR TITLE
fix: add pull-requests write permission to super-linter workflow

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
   statuses: write
 ###############
 # Set the Job #


### PR DESCRIPTION
Added pull-requests: write permission to fix 403 error when calling GitHub API