### PR TITLE
fix(ci): use client-id instead of deprecated app-id for GitHub App token

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          client-id: ${{ secrets.PROJECT_AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
https://github.com/massongit/aws-management-console-colorize/actions/runs/28629574810/job/84903370864#step:18:1

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

I use `client-id` because `app-id` is deprecated.