### PR TITLE
CI release: Chrome Web Store API v2を使う

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
                --chrome-zip dist/*-chrome.zip \
                --firefox-zip dist/*-firefox.zip --firefox-sources-zip dist/*-sources.zip
         env:
+          CHROME_API_VERSION: v2
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}


### PR DESCRIPTION
https://github.com/massongit/aws-management-console-colorize/actions/runs/31865380357/job/94965479598#step:8:16

```
‼ Chrome Web Store API v1.1 is deprecated and will stop working October 15th, 2026. Run publish-extension init or wxt submit init to set up your API v2 credentials.
```

とのことなので、Chrome Web Store API v2を使うようにします。